### PR TITLE
design: 온보딩 화면 구현

### DIFF
--- a/yeogijeogi/Assets.xcassets/Colors/Error.colorset/Contents.json
+++ b/yeogijeogi/Assets.xcassets/Colors/Error.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0x35",
+          "red" : "0xDC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yeogijeogi/Assets.xcassets/Colors/OnSurfaceVariant.colorset/Contents.json
+++ b/yeogijeogi/Assets.xcassets/Colors/OnSurfaceVariant.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA6",
+          "green" : "0xA4",
+          "red" : "0xA2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yeogijeogi/Assets.xcassets/Colors/Success.colorset/Contents.json
+++ b/yeogijeogi/Assets.xcassets/Colors/Success.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0x87",
+          "red" : "0x19"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/yeogijeogi/components/CustomSlider.swift
+++ b/yeogijeogi/components/CustomSlider.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import UIKit
+
+class CustomHeightSlider: UISlider {
+    override func trackRect(forBounds bounds: CGRect) -> CGRect {
+        var rect = super.trackRect(forBounds: bounds)
+        rect.size.height = 8
+        return rect
+    }
+}
+
+struct CustomSlider: UIViewRepresentable {
+    @Binding var value: Double
+
+    func makeUIView(context: Context) -> UISlider {
+        let slider = CustomHeightSlider(frame: .zero)
+
+        slider.minimumTrackTintColor = .surface
+        slider.maximumTrackTintColor = .surface
+        slider.minimumValue = -5.0
+        slider.maximumValue = 5.0
+
+        slider.setThumbImage(UIImage(systemName: "circle.fill")?
+            .withTintColor(.primaryGreen, renderingMode: .alwaysOriginal)
+            .resized(to: CGSize(width: 16, height: 16)),
+            for: .normal)
+
+        slider.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.valueChanged(_:)),
+            for: .valueChanged
+        )
+
+        return slider
+    }
+
+    func updateUIView(_ uiView: UISlider, context: Context) {
+        uiView.setValue(Float(value), animated: true)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(value: $value, step: 1)
+    }
+
+    class Coordinator: NSObject {
+        @Binding var value: Double
+        var step: Double
+
+        init(value: Binding<Double>, step: Double) {
+            self._value = value
+            self.step = step
+        }
+
+        @objc func valueChanged(_ sender: UISlider) {
+            let roundedValue = round(Double(sender.value) / step) * step
+            sender.value = Float(roundedValue)
+            value = roundedValue
+        }
+    }
+}
+
+extension UIImage {
+    func resized(to size: CGSize) -> UIImage {
+        return UIGraphicsImageRenderer(size: size).image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/yeogijeogi/components/LargeButton.swift
+++ b/yeogijeogi/components/LargeButton.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct LargeButton: View {
+    let title: String
+
+    var body: some View {
+        Button {} label: {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.surface)
+                .frame(maxWidth: .infinity)
+        }
+        .frame(height: 56)
+        .background(.primaryGreen)
+        .cornerRadius(20)
+    }
+}
+
+#Preview {
+    LargeButton(title: "버튼")
+}

--- a/yeogijeogi/components/LoginButton.swift
+++ b/yeogijeogi/components/LoginButton.swift
@@ -17,13 +17,12 @@ struct LoginButton: View {
             .frame(height: 48)
             .padding(.horizontal, 20)
         }
-        .frame(maxWidth: .infinity)
-        .buttonStyle(.borderedProminent)
-        .tint(.container)
+        .frame(width: .infinity, height: 48)
+        .background(.container)
         .cornerRadius(10)
     }
 }
 
 #Preview {
-    LoginButton(type: .apple)
+    LoginView()
 }

--- a/yeogijeogi/components/SliderContainer.swift
+++ b/yeogijeogi/components/SliderContainer.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct SliderContainer: View {
+    let title: String
+    let valueTexts: [String]
+
+    @State private var value = 0.0
+
+    var body: some View {
+        VStack {
+            Text(title)
+                .font(.body)
+                .foregroundStyle(.onSurface)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer()
+                .frame(height: 20)
+
+            CustomSlider(value: $value)
+
+            Spacer()
+                .frame(height: 8)
+
+            ZStack {
+                HStack {
+                    Text(valueTexts[0])
+                        .font(.caption)
+                        .foregroundStyle(.onSurfaceVariant)
+                    Spacer()
+
+                    Text(valueTexts[2])
+                        .font(.caption)
+                        .foregroundStyle(.onSurfaceVariant)
+                }
+
+                Text(valueTexts[1])
+                    .font(.caption)
+                    .foregroundStyle(.onSurfaceVariant)
+            }
+        }
+        .frame(width: .infinity, height: 120)
+        .padding(.horizontal, 20)
+        .background(.container)
+        .cornerRadius(20)
+    }
+}
+
+#Preview {
+    OnboardingView()
+}

--- a/yeogijeogi/components/TimeSelectContainer.swift
+++ b/yeogijeogi/components/TimeSelectContainer.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct TimeSelectContainer: View {
+    var body: some View {
+        HStack {
+            Text("얼마나 걸을까요?")
+                .font(.body)
+                .foregroundStyle(.onSurface)
+            Spacer()
+
+            Button {} label: {
+                Text("1시간 30분")
+                    .font(.body)
+                    .foregroundStyle(.onSurface)
+            }
+            .frame(width: 128, height: 36)
+            .background(.surface)
+            .cornerRadius(10)
+        }
+        .frame(width: .infinity, height: 64)
+        .padding(.horizontal, 20)
+        .background(.container)
+        .cornerRadius(20)
+    }
+}
+
+#Preview {
+    OnboardingView()
+}

--- a/yeogijeogi/utils/Surface.swift
+++ b/yeogijeogi/utils/Surface.swift
@@ -13,6 +13,7 @@ struct Surface: ViewModifier {
                 .ignoresSafeArea()
 
             content
+                .padding(.horizontal, 20)
         }
     }
 }

--- a/yeogijeogi/views/LoginView.swift
+++ b/yeogijeogi/views/LoginView.swift
@@ -13,7 +13,6 @@ struct LoginView: View {
             Spacer()
                 .frame(height: 98)
         }
-        .padding(.horizontal, 20)
         .surface()
     }
 }

--- a/yeogijeogi/views/OnboardingView.swift
+++ b/yeogijeogi/views/OnboardingView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    var body: some View {
+        VStack {
+            Text("산책을 떠나 볼까요?")
+                .font(.title)
+                .foregroundStyle(.onSurface)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer()
+                .frame(height: 8)
+
+            Text("산책 코스 추천을 위해 몇가지 질문에 대답해 주세요.")
+                .font(.headline)
+                .foregroundStyle(.onSurface)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer()
+                .frame(height: 40)
+
+            TimeSelectContainer()
+            Spacer()
+                .frame(height: 24)
+
+            SliderContainer(title: "어떤 분위기를 원하시나요?", valueTexts: ["자연", "상관 없음", "도시"])
+                .tint(.surface)
+            Spacer()
+                .frame(height: 24)
+
+            SliderContainer(title: "산책 강도를 선택해 주세요.", valueTexts: ["가벼운", "상관 없음", "운동되는"])
+                .tint(.surface)
+            Spacer()
+
+            LargeButton(title: "코스 추천 받기")
+        }
+        .surface()
+    }
+}
+
+#Preview {
+    OnboardingView()
+}


### PR DESCRIPTION
## 📝작업 내용
시간 선택 컨테이너 컴포넌트 구현

슬라이더 컨테이너 컴포넌트 구현
- 커스텀 슬라이더 구현 (슬라이더 색상, 슬라이더 두께, 노브 색상 등)

메인 버튼 컴포넌트 구현
- 로그인 버튼 스타일 피그마에 맞게 수정 (height, background)

Onboarding View 구현

Surface() 에 horizontal 패딩도 포함하도록 수정

색상 추가
- Error
- Success
- OnSurfaceVariant

## 스크린샷
<img width="20%" src="https://github.com/user-attachments/assets/d5449640-62cc-478e-b8be-3ce043ab2e21" />