### PR TITLE
design: 코스 화면 디자인 구현

### DIFF
--- a/yeogijeogi/components/CourseSummary.swift
+++ b/yeogijeogi/components/CourseSummary.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct CourseSummary: View {
+    var body: some View {
+        ImageContainer()
+        Spacer()
+            .frame(height: 24)
+
+        CourseInfoContainer()
+        Spacer()
+            .frame(height: 24)
+
+        SliderContainer(title: "분위기가 어떘나요?", valueTexts: ["자연", "", "도시"])
+        Spacer()
+            .frame(height: 24)
+
+        SliderContainer(title: "산책 강도는 어떘나요?", valueTexts: ["쉬움", "적당함", "어려움"])
+        Spacer()
+            .frame(height: 24)
+
+        MemoContainer()
+        Spacer()
+            .frame(height: 40)
+    }
+}
+
+#Preview {
+    CourseSummary()
+}

--- a/yeogijeogi/components/NaverMap.swift
+++ b/yeogijeogi/components/NaverMap.swift
@@ -1,0 +1,35 @@
+import NMapsMap
+import SwiftUI
+
+struct NaverMap: UIViewRepresentable {
+    var coord: (Double, Double) = (127.0278, 37.59080)
+    var positionMode: NMFMyPositionMode = .disabled
+    var zoomLevel: Double = 17
+    var isScrollGestureEnabled: Bool = true
+    var isZoomGestureEnabled: Bool = true
+
+    func makeUIView(context: Context) -> NMFNaverMapView {
+        let view = NMFNaverMapView()
+        view.showZoomControls = false
+        view.showScaleBar = false
+        view.mapView.positionMode = .disabled
+        view.mapView.zoomLevel = zoomLevel
+        view.mapView.isScrollGestureEnabled = isScrollGestureEnabled
+        view.mapView.isZoomGestureEnabled = isZoomGestureEnabled
+        view.mapView.logoAlign = .leftTop
+
+        return view
+    }
+
+    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
+        let coord = NMGLatLng(lat: coord.1, lng: coord.0)
+        let cameraUpdate = NMFCameraUpdate(scrollTo: coord)
+        cameraUpdate.animation = .fly
+        cameraUpdate.animationDuration = 1
+        uiView.mapView.moveCamera(cameraUpdate)
+    }
+}
+
+#Preview {
+    NaverMap()
+}

--- a/yeogijeogi/views/CourseDetailView.swift
+++ b/yeogijeogi/views/CourseDetailView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct CourseDetailView: View {
+    let selectedDetent: PresentationDetent
+
+    var body: some View {
+        if selectedDetent == .large {
+            NavigationStack {
+                ScrollView {
+                    VStack {
+                        CourseSummary()
+
+                        Button {} label: {
+                            Text("삭제하기")
+                                .font(.caption)
+                                .foregroundStyle(.error)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+                .navigationTitle("산책 코스 상세 보기")
+                .navigationBarTitleDisplayMode(.inline)
+                .surface(applyPadding: false)
+            }
+        } else {
+            VStack {
+                //        Text("아직 산책한 코스가 없어요.")
+                //            .font(.headline)
+                //            .foregroundStyle(.onSurface)
+
+                CourseInfoContainer()
+            }
+            .surface()
+        }
+    }
+}
+
+#Preview {
+    CourseDetailView(selectedDetent: .large)
+}

--- a/yeogijeogi/views/CourseView.swift
+++ b/yeogijeogi/views/CourseView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct CourseView: View {
+    @State private var selectedDetent: PresentationDetent = .height(173)
+
+    var body: some View {
+        ZStack {
+            NaverMap()
+                .ignoresSafeArea()
+                .sheet(isPresented: .constant(true)) {
+                    CourseDetailView(selectedDetent: selectedDetent)
+                        .presentationDetents(
+                            [.height(173), .large],
+                            selection: $selectedDetent
+                        )
+                        .interactiveDismissDisabled(true)
+                        .presentationBackgroundInteraction(
+                            .enabled(upThrough: .height(173))
+                        )
+                        .presentationCornerRadius(20)
+                }
+        }
+    }
+}
+
+#Preview {
+    CourseView()
+}

--- a/yeogijeogi/views/WalkSaveView.swift
+++ b/yeogijeogi/views/WalkSaveView.swift
@@ -18,25 +18,7 @@ struct WalkSaveView: View {
                 Spacer()
                     .frame(height: 40)
 
-                ImageContainer()
-                Spacer()
-                    .frame(height: 24)
-
-                CourseInfoContainer()
-                Spacer()
-                    .frame(height: 24)
-
-                SliderContainer(title: "분위기가 어떘나요?", valueTexts: ["자연", "", "도시"])
-                Spacer()
-                    .frame(height: 24)
-
-                SliderContainer(title: "산책 강도는 어떘나요?", valueTexts: ["쉬움", "적당함", "어려움"])
-                Spacer()
-                    .frame(height: 24)
-
-                MemoContainer()
-                Spacer()
-                    .frame(height: 40)
+                CourseSummary()
 
                 LargeButton(title: "산책 코스 저장하기")
             }

--- a/yeogijeogi/views/WalkSelectView.swift
+++ b/yeogijeogi/views/WalkSelectView.swift
@@ -1,4 +1,3 @@
-import NMapsMap
 import SwiftUI
 
 struct WalkSelectView: View {
@@ -12,8 +11,11 @@ struct WalkSelectView: View {
                 .frame(height: 40)
 
             ZStack(alignment: .bottom) {
-                NaverMap(coord: (126.9784147, 37.5666805))
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                NaverMap(
+                    isScrollGestureEnabled: false,
+                    isZoomGestureEnabled: false
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 20))
 
                 CourseInfoContainer()
                     .padding(20)
@@ -28,31 +30,6 @@ struct WalkSelectView: View {
             LargeButton(title: "산책 시작하기")
         }
         .surface()
-    }
-}
-
-struct NaverMap: UIViewRepresentable {
-    var coord: (Double, Double)
-
-    func makeUIView(context: Context) -> NMFNaverMapView {
-        let view = NMFNaverMapView()
-        view.showZoomControls = false
-        view.showScaleBar = false
-        view.mapView.positionMode = .disabled
-        view.mapView.zoomLevel = 17
-        view.mapView.isScrollGestureEnabled = false
-        view.mapView.isZoomGestureEnabled = false
-        view.mapView.logoMargin = UIEdgeInsets(top: 0, left: 0, bottom: 153, right: 0)
-
-        return view
-    }
-
-    func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
-        let coord = NMGLatLng(lat: coord.1, lng: coord.0)
-        let cameraUpdate = NMFCameraUpdate(scrollTo: coord)
-        cameraUpdate.animation = .fly
-        cameraUpdate.animationDuration = 1
-        uiView.mapView.moveCamera(cameraUpdate)
     }
 }
 


### PR DESCRIPTION
## 📝 작업 내용
네이버 지도 컴포넌트로 변경
- 기존 WalkSelectView에 있던 지도를 컴포넌트로 분리
- 상황에 맞게 커스텀 가능하도록 변수 지정

산책 정보 재사용 가능하도록 컴포넌트 분리
- 기존 WalkSaveView에 있던 내용 분리
- 이미지, 요약, 분위기/강도 슬라이더, 메모

산책 코스 모달 페이지 디자인 구현
- detent 크기 173, `.large` 로 구분
- 크기에 맞게 요약 정보 또는 전체 상세 정보 화면이 표시되도록 구현

코스 화면 구현
- 네이버 지도 표시 및 모달 표시

## 📷 스크린샷
<img width="20%" src="https://github.com/user-attachments/assets/131f3359-6558-44ae-8e8b-0d7901cff0f8" />
<img width="20%" src="https://github.com/user-attachments/assets/8763171a-a9d8-4807-8fdb-4b6a44b1c55a" />

