### PR TITLE
feat: 산책 화면 라우터 설정

### DIFF
--- a/yeogijeogi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/yeogijeogi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d23c2ef9e569abb4bc17482e7fe38010cde84dbd6c23b102226d5eef12ba34c2",
+  "originHash" : "11066d915e223aa374d486972a815ff102159d0909f22b506486c07f9aa260bd",
   "pins" : [
     {
       "identity" : "bottomsheet",

--- a/yeogijeogi/components/CustomTabView.swift
+++ b/yeogijeogi/components/CustomTabView.swift
@@ -4,30 +4,37 @@ struct CustomTabView: View {
     @Binding var selectedTab: Tab
 
     var body: some View {
-        HStack {
+        VStack {
             Spacer()
+                .frame(height: 16)
 
-            ForEach(Tab.allCases, id: \.self) { tab in
-                Button {
-                    self.selectedTab = tab
-                } label: {
-                    VStack {
-                        Image(tab.icon)
-                            .tint(selectedTab == tab ? .onSurface : .onSurfaceVariant)
-                        Spacer()
-                            .frame(height: 8)
-
-                        Text(tab.title)
-                            .font(.caption)
-                            .foregroundStyle(selectedTab == tab ? .onSurface : .onSurfaceVariant)
-                    }
-                }
-                .frame(width: 52)
-
+            HStack {
                 Spacer()
+
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Button {
+                        self.selectedTab = tab
+                    } label: {
+                        VStack {
+                            Image(tab.icon)
+                                .tint(selectedTab == tab ? .onSurface : .onSurfaceVariant)
+                            Spacer()
+                                .frame(height: 8)
+
+                            Text(tab.title)
+                                .font(.caption)
+                                .foregroundStyle(selectedTab == tab ? .onSurface : .onSurfaceVariant)
+                        }
+                    }
+                    .frame(width: 52)
+
+                    Spacer()
+                }
             }
+            .frame(maxWidth: .infinity)
+
+            Spacer()
         }
-        .frame(maxWidth: .infinity)
         .frame(height: 90)
         .background(.container)
         .clipShape(.rect(topLeadingRadius: 20, topTrailingRadius: 20))

--- a/yeogijeogi/components/LargeButton.swift
+++ b/yeogijeogi/components/LargeButton.swift
@@ -2,9 +2,10 @@ import SwiftUI
 
 struct LargeButton: View {
     let title: String
+    let action: () -> Void
 
     var body: some View {
-        Button {} label: {
+        Button(action: action) {
             Text(title)
                 .font(.headline)
                 .foregroundStyle(.surface)
@@ -17,5 +18,5 @@ struct LargeButton: View {
 }
 
 #Preview {
-    LargeButton(title: "버튼")
+    LargeButton(title: "버튼") {}
 }

--- a/yeogijeogi/components/SettingContainer.swift
+++ b/yeogijeogi/components/SettingContainer.swift
@@ -16,7 +16,7 @@ struct SettingContainer: View {
                     .foregroundStyle(.onSurfaceVariant)
             }
             .padding(.horizontal, 20)
-            .frame(width: .infinity, height: 40, alignment: .leading)
+            .frame(height: 40, alignment: .leading)
             .background(.container)
 
             Button {} label: {
@@ -32,7 +32,7 @@ struct SettingContainer: View {
                 }
             }
             .padding(.horizontal, 20)
-            .frame(width: .infinity, height: 40, alignment: .leading)
+            .frame(height: 40, alignment: .leading)
             .background(.container)
 
             Button {} label: {
@@ -48,7 +48,7 @@ struct SettingContainer: View {
                 }
             }
             .padding(.horizontal, 20)
-            .frame(width: .infinity, height: 40, alignment: .leading)
+            .frame(height: 40, alignment: .leading)
             .background(.container)
             Spacer()
         }

--- a/yeogijeogi/enums/Route.swift
+++ b/yeogijeogi/enums/Route.swift
@@ -1,0 +1,5 @@
+enum Route {
+    case walkSelect
+    case walk
+    case walkSave
+}

--- a/yeogijeogi/enums/Route.swift
+++ b/yeogijeogi/enums/Route.swift
@@ -1,4 +1,4 @@
-enum Route {
+enum Route: Hashable {
     case walkSelect
     case walk
     case walkSave

--- a/yeogijeogi/utils/Router.swift
+++ b/yeogijeogi/utils/Router.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@MainActor
+class Router: ObservableObject {
+    @Published var tab: Tab = .walk {
+        didSet {
+            if oldValue != tab {
+                path.removeAll()
+            }
+        }
+    }
+
+    @Published var path: [Route] = []
+}

--- a/yeogijeogi/views/ContentView.swift
+++ b/yeogijeogi/views/ContentView.swift
@@ -1,22 +1,36 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var selectedTab: Tab = .walk
+    @EnvironmentObject private var router: Router
 
     var body: some View {
         VStack(spacing: 0) {
-            switch selectedTab {
+            switch router.tab {
             case .course:
                 CourseView()
 
             case .walk:
-                OnboardingView()
+                NavigationStack(path: $router.path) {
+                    OnboardingView()
+                        .navigationDestination(for: Route.self) { route in
+                            switch route {
+                            case Route.walkSelect:
+                                WalkSelectView()
+                            case Route.walk:
+                                WalkView()
+                            case Route.walkSave:
+                                WalkSaveView()
+                            }
+                        }
+                }
 
             case .myPage:
                 MyPageView()
             }
 
-            CustomTabView(selectedTab: $selectedTab)
+            if router.path.last != Route.walk && router.path.last != Route.walkSave {
+                CustomTabView(selectedTab: $router.tab)
+            }
         }
         .background(.surface)
         .ignoresSafeArea(edges: .bottom)
@@ -25,4 +39,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(Router())
 }

--- a/yeogijeogi/views/OnboardingView.swift
+++ b/yeogijeogi/views/OnboardingView.swift
@@ -1,22 +1,16 @@
 import SwiftUI
 
 struct OnboardingView: View {
+    @EnvironmentObject private var router: Router
+
     var body: some View {
         VStack {
-            Text("산책을 떠나 볼까요?")
-                .font(.title)
-                .foregroundStyle(.onSurface)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            Spacer()
-                .frame(height: 8)
-
             Text("산책 코스 추천을 위해 몇가지 질문에 대답해 주세요.")
                 .font(.headline)
                 .foregroundStyle(.onSurface)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Spacer()
-                .frame(height: 40)
+                .frame(height: 24)
 
             ButtonContainer(title: "얼마나 걸을까요?", buttonText: "1시간 30분")
             Spacer()
@@ -31,12 +25,17 @@ struct OnboardingView: View {
                 .tint(.surface)
             Spacer()
 
-            LargeButton(title: "코스 추천 받기")
+            LargeButton(title: "코스 추천 받기") {
+                router.path.append(Route.walkSelect)
+            }
         }
         .surface()
+        .navigationTitle("산책을 떠나 볼까요?")
+        .navigationBarTitleDisplayMode(.large)
     }
 }
 
 #Preview {
     OnboardingView()
+        .environmentObject(Router())
 }

--- a/yeogijeogi/views/WalkSaveView.swift
+++ b/yeogijeogi/views/WalkSaveView.swift
@@ -1,33 +1,35 @@
 import SwiftUI
 
 struct WalkSaveView: View {
+    @EnvironmentObject private var router: Router
+
     var body: some View {
         ScrollView {
             VStack {
-                Text("산책 코스는 어땠나요?")
-                    .font(.title)
-                    .foregroundStyle(.onSurface)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Spacer()
-                    .frame(height: 8)
-
                 Text("산책이 어땠는지 간단하게 정리해 보세요.")
                     .font(.headline)
                     .foregroundStyle(.onSurface)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Spacer()
-                    .frame(height: 40)
+                    .frame(height: 24)
 
                 CourseSummary()
 
-                LargeButton(title: "산책 코스 저장하기")
+                LargeButton(title: "산책 코스 저장하기") {
+                    router.tab = .course
+                }
             }
             .padding(.horizontal, 20)
+            .padding(.bottom, 20)
         }
         .surface(applyPadding: false)
+        .navigationTitle("산책 코스는 어땠나요?")
+        .navigationBarTitleDisplayMode(.large)
+        .navigationBarBackButtonHidden()
     }
 }
 
 #Preview {
     WalkSaveView()
+        .environmentObject(Router())
 }

--- a/yeogijeogi/views/WalkSelectView.swift
+++ b/yeogijeogi/views/WalkSelectView.swift
@@ -1,14 +1,13 @@
 import SwiftUI
 
 struct WalkSelectView: View {
+    @EnvironmentObject private var router: Router
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
         VStack {
-            Text("이런 코스를 추천해요!")
-                .font(.title)
-                .foregroundStyle(.onSurface)
-                .frame(maxWidth: .infinity, alignment: .leading)
             Spacer()
-                .frame(height: 40)
+                .frame(height: 24)
 
             ZStack(alignment: .bottom) {
                 NaverMap(
@@ -28,8 +27,13 @@ struct WalkSelectView: View {
             Spacer()
                 .frame(height: 20)
 
-            LargeButton(title: "산책 시작하기")
+            LargeButton(title: "산책 시작하기") {
+                router.path.append(Route.walk)
+            }
         }
+        .navigationTitle("이런 코스를 추천해요!")
+        .navigationBarTitleDisplayMode(.large)
+        .navigationBarBackButtonHidden()
         .surface()
     }
 }

--- a/yeogijeogi/views/WalkView.swift
+++ b/yeogijeogi/views/WalkView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct WalkView: View {
+    @EnvironmentObject private var router: Router
+
     var body: some View {
         ZStack(alignment: .bottom) {
             NaverMap(
@@ -9,12 +11,16 @@ struct WalkView: View {
             )
             .ignoresSafeArea()
 
-            LargeButton(title: "산책 종료하기")
-                .padding(20)
+            LargeButton(title: "산책 종료하기") {
+                router.path.append(Route.walkSave)
+            }
+            .padding(20)
         }
+        .navigationBarBackButtonHidden()
     }
 }
 
 #Preview {
     WalkView()
+        .environmentObject(Router())
 }

--- a/yeogijeogi/yeogijeogiApp.swift
+++ b/yeogijeogi/yeogijeogiApp.swift
@@ -9,9 +9,13 @@ import SwiftUI
 
 @main
 struct yeogijeogiApp: App {
+    @StateObject private var router = Router()
+
     var body: some Scene {
         WindowGroup {
-            LoginView()
+//            LoginView()
+            ContentView()
+                .environmentObject(router)
         }
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
산책 화면들에 라우터 연결
- 산책 저장시 코스 화면으로 이동

Router 모델 정의
- 현재 탭, path 정보 저장
- 탭을 변경하면 path는 초기화 되도록 로직 구현
- path으로 사용할 Route enum 정의

산책 화면들의 대제목을 `.navigationTitle`로 변경

`LargeButton`에 action 변수 추가
- 버튼 클릭시 실행할 함수 정의