### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/yeogijeogi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/yeogijeogi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "efde9fe4990a9fb6cfd1b40729bf56136f8f35494ae3c563700e3b9d9076b860",
+  "originHash" : "3fe79b81e4abd85802f1b4498546b1a4e1d0b63e0a37d2f8eed006d739c9811c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/yeogijeogi/api/BaseInterceptor.swift
+++ b/yeogijeogi/api/BaseInterceptor.swift
@@ -10,7 +10,7 @@ final class BaseInterceptor: RequestInterceptor {
             return
         }
 
-        user.getIDToken { token, error in
+        user.getIDTokenForcingRefresh(true) { token, error in
             if let error = error {
                 completion(.failure(error))
                 return

--- a/yeogijeogi/api/routers/UserRouter.swift
+++ b/yeogijeogi/api/routers/UserRouter.swift
@@ -2,13 +2,13 @@ import Alamofire
 import Foundation
 
 enum UserRouter: RouterInterface {
-    case createUser
+    case createUser, deleteUser
 
     var modulePath: String { "/user" }
 
     var path: String {
         switch self {
-        case .createUser:
+        case .createUser, .deleteUser:
             return "/"
         }
     }
@@ -17,12 +17,14 @@ enum UserRouter: RouterInterface {
         switch self {
         case .createUser:
             return .post
+        case .deleteUser:
+            return .delete
         }
     }
 
     var parameters: Parameters? {
         switch self {
-        case .createUser:
+        case .createUser, .deleteUser:
             return nil
         }
     }

--- a/yeogijeogi/api/services/UserService.swift
+++ b/yeogijeogi/api/services/UserService.swift
@@ -6,4 +6,8 @@ class UserService {
     func createUser(completion: @escaping (Result<Void, ErrorDetail>) -> Void) {
         APIService.request(UserRouter.createUser, completion: completion)
     }
+
+    func deleteUser(completion: @escaping (Result<Void, ErrorDetail>) -> Void) {
+        APIService.request(UserRouter.deleteUser, completion: completion)
+    }
 }

--- a/yeogijeogi/auth/AppleSignIn.swift
+++ b/yeogijeogi/auth/AppleSignIn.swift
@@ -25,6 +25,10 @@ class AppleSignIn: NSObject, AuthenticationStrategy {
     // 애플 로그인은 별도의 클라이언트 측 로그아웃 API가 필요하지 않음
     func signOut() {}
 
+    func withdraw(completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+
     private func randomNonceString(length: Int = 32) -> String {
         precondition(length > 0)
         var randomBytes = [UInt8](repeating: 0, count: length)

--- a/yeogijeogi/auth/AuthenticationStrategy.swift
+++ b/yeogijeogi/auth/AuthenticationStrategy.swift
@@ -3,4 +3,5 @@ import FirebaseAuth
 protocol AuthenticationStrategy {
     func signIn(completion: @escaping (Result<AuthCredential, Error>) -> Void)
     func signOut()
+    func withdraw(completion: @escaping (Error?) -> Void)
 }

--- a/yeogijeogi/auth/Authenticator.swift
+++ b/yeogijeogi/auth/Authenticator.swift
@@ -6,9 +6,40 @@ class Authenticator: ObservableObject {
     @Published var signState: SignState = .signOut
     
     private var strategy: AuthenticationStrategy?
-    
+    private var user: User?
+
     func checkSignState() {
-        signState = Auth.auth().currentUser != nil ? .signIn : .signOut
+        guard let user = Auth.auth().currentUser else {
+            updateSignState(.signOut)
+            return
+        }
+        
+        self.user = user
+//        user.getIDToken { token, _ in
+//            if let token = token {
+//                print(token)
+//            }
+//        }
+                
+        guard let providerData = user.providerData.first else {
+            updateSignState(.signOut)
+            print("Failed to get strategy: provider data not found")
+            return
+        }
+                
+        do {
+            switch try LoginType.fromProviderId(providerId: providerData.providerID) {
+            case .apple:
+                strategy = AppleSignIn()
+            case .google:
+                strategy = GoogleSignIn(presentingViewController: nil)
+            }
+        } catch {
+            updateSignState(.signOut)
+            print("Failed to get strategy: \(error.localizedDescription)")
+        }
+        
+        updateSignState(.signIn)
     }
     
     func signIn(with strategy: AuthenticationStrategy) {
@@ -19,33 +50,7 @@ class Authenticator: ObservableObject {
                     
             switch result {
             case .success(let credential):
-                Auth.auth().signIn(with: credential) { authResult, error in
-                    if let error = error {
-                        print("Firebase signIn error: \(error.localizedDescription)")
-                        return
-                    }
-                    
-                    guard let authResult = authResult else {
-                        print("Auth result is nil.")
-                        return
-                    }
-                        
-                    if let userInfo = authResult.additionalUserInfo, userInfo.isNewUser {
-                        UserService.shared.createUser { result in
-                            switch result {
-                            case .success:
-                                return
-                            case .failure(let error):
-                                print(error.detail)
-                                return
-                            }
-                        }
-                    }
-                    
-                    DispatchQueue.main.async {
-                        self.signState = .signIn
-                    }
-                }
+                self.firebaseSignin(with: credential)
             case .failure(let error):
                 print("Authentication strategy error: \(error.localizedDescription)")
             }
@@ -53,13 +58,86 @@ class Authenticator: ObservableObject {
     }
     
     func signOut() {
-        strategy?.signOut()
+        guard let strategy else {
+            print("Failed to sign out: strategy is nil")
+            return
+        }
         
+        strategy.signOut()
+                
         do {
             try Auth.auth().signOut()
-            signState = .signOut
+            updateSignState(.signOut)
         } catch {
-            print(error.localizedDescription)
+            print("Firebase signOut error: \(error.localizedDescription)")
+        }
+    }
+    
+    func withdraw() {
+        guard let strategy else {
+            print("Failed to withdraw user: strategy is nil")
+            return
+        }
+        
+        UserService.shared.deleteUser { [weak self] result in
+            guard let self else { return }
+                    
+            switch result {
+            case .success:
+                strategy.withdraw { error in
+                    if let error = error {
+                        print("Failed to withdraw user: \(error.localizedDescription)")
+                        return
+                    }
+                    self.signOut()
+                    print("Withdraw completed successfully")
+                }
+            case .failure(let error):
+                print(error.detail)
+            }
+        }
+    }
+    
+    private func updateSignState(_ state: SignState) {
+        DispatchQueue.main.async {
+            self.signState = state
+            
+            if case .signOut = state {
+                self.user = nil
+                self.strategy = nil
+            }
+        }
+    }
+    
+    private func firebaseSignin(with credential: AuthCredential) {
+        Auth.auth().signIn(with: credential) { authResult, error in
+            if let error = error {
+                print("Firebase signIn error: \(error.localizedDescription)")
+                return
+            }
+            
+            guard let authResult = authResult else {
+                print("Auth result is nil.")
+                return
+            }
+                
+            if let userInfo = authResult.additionalUserInfo, userInfo.isNewUser {
+                UserService.shared.createUser { result in
+                    switch result {
+                    case .success:
+                        DispatchQueue.main.async {
+                            self.signState = .signIn
+                        }
+                    case .failure(let error):
+                        print(error.detail)
+                        return
+                    }
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.signState = .signIn
+                }
+            }
         }
     }
 }

--- a/yeogijeogi/auth/Authenticator.swift
+++ b/yeogijeogi/auth/Authenticator.swift
@@ -125,18 +125,14 @@ class Authenticator: ObservableObject {
                 UserService.shared.createUser { result in
                     switch result {
                     case .success:
-                        DispatchQueue.main.async {
-                            self.signState = .signIn
-                        }
+                        self.updateSignState(.signIn)
                     case .failure(let error):
                         print(error.detail)
                         return
                     }
                 }
             } else {
-                DispatchQueue.main.async {
-                    self.signState = .signIn
-                }
+                self.updateSignState(.signIn)
             }
         }
     }

--- a/yeogijeogi/auth/GoogleSignIn.swift
+++ b/yeogijeogi/auth/GoogleSignIn.swift
@@ -5,7 +5,7 @@ import GoogleSignIn
 class GoogleSignIn: NSObject, AuthenticationStrategy {
     private weak var presentingViewController: UIViewController?
 
-    init(presentingViewController: UIViewController) {
+    init(presentingViewController: UIViewController?) {
         self.presentingViewController = presentingViewController
     }
 
@@ -43,5 +43,17 @@ class GoogleSignIn: NSObject, AuthenticationStrategy {
     
     func signOut() {
         GIDSignIn.sharedInstance.signOut()
+    }
+    
+    func withdraw(completion: @escaping (Error?) -> Void) {
+        GIDSignIn.sharedInstance.disconnect { error in
+            if let error = error {
+                print("Error disconnecting Google user: \(error.localizedDescription)")
+                completion(error)
+                return
+            }
+            print("Successfully disconnected Google user.")
+            completion(nil)
+        }
     }
 }

--- a/yeogijeogi/enums/LoginType.swift
+++ b/yeogijeogi/enums/LoginType.swift
@@ -4,6 +4,10 @@ enum LoginType {
     case google
     case apple
 
+    enum LoginTypeError: Error {
+        case unknownProvider(String)
+    }
+
     var text: String {
         switch self {
         case .google:
@@ -19,6 +23,17 @@ enum LoginType {
             return .googleLogo
         case .apple:
             return .appleLogo
+        }
+    }
+
+    static func fromProviderId(providerId: String) throws -> LoginType {
+        switch providerId {
+        case "google.com":
+            return .google
+        case "apple.com":
+            return .apple
+        default:
+            throw LoginTypeError.unknownProvider(providerId)
         }
     }
 }

--- a/yeogijeogi/views/MyPageView.swift
+++ b/yeogijeogi/views/MyPageView.swift
@@ -48,7 +48,9 @@ struct MyPageView: View {
 
                 HStack {
                     Button {
-                        dialogManager.show(.withdraw)
+                        dialogManager.show(.withdraw) {
+                            authenticator.withdraw()
+                        }
                     } label: {
                         Text("회원탈퇴")
                             .font(.caption)


### PR DESCRIPTION
## 📝 작업 내용
회원 탈퇴 기능 구현
- UserRouter, UserService에 DELETE /user/ api 연결

Authentication Strategy에 withdraw 로직 추가
- 구글 : 계정 연결 해제
- 애플 : 백엔드에서 추가 로직 구현 필요

Authenticator 리팩토링 
- api 호출 후 성공시 withdraw 진행하도록 로직 구현
- 중복된 코드 함수로 분리 

LoginType에 firebase provider id > LoginType 반환하는 함수 구현

BaseInterceptor에 토큰 불러올 때 refresh 필요하다면 하도록 수정